### PR TITLE
Fix incorrect screen imports and paths

### DIFF
--- a/app/add-printer.js
+++ b/app/add-printer.js
@@ -1,5 +1,5 @@
 import { View, StyleSheet } from 'react-native';
-import { AddPrinterScreen } from './screens/AddPrinterScreen';
+import AddPrinterScreen from './screens/AddPrinterScreen';
 
 export default function AddPrinterRoute() {
   return (

--- a/app/checklist.js
+++ b/app/checklist.js
@@ -1,5 +1,5 @@
 import { View, StyleSheet } from 'react-native';
-import { ChecklistScreen } from './screens/ChecklistScreen';
+import ChecklistScreen from './screens/ChecklistScreen';
 
 export default function ChecklistRoute() {
   return (

--- a/app/index.js
+++ b/app/index.js
@@ -1,6 +1,5 @@
-import { View, Text, StyleSheet, Button } from 'react-native';
-import { Link } from 'expo-router';
-import { HomeScreen } from './screens/HomeScreen';
+import { View, StyleSheet } from 'react-native';
+import HomeScreen from './screens/HomeScreen';
 
 export default function Home() {
   return (

--- a/app/screens/ChecklistScreen.tsx
+++ b/app/screens/ChecklistScreen.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { View, Text, FlatList, StyleSheet } from 'react-native';
-import Checklist from '../components/Checklist';
-import { usePrinters } from '../hooks/usePrinters';
+import { View, Text, StyleSheet } from 'react-native';
+import Checklist from '../../components/Checklist';
+import usePrinters from '../../hooks/usePrinters';
 
 const ChecklistScreen = ({ route }) => {
     const { printerId } = route.params;

--- a/components/PrinterList.tsx
+++ b/components/PrinterList.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { View, Text, FlatList, TouchableOpacity } from 'react-native';
-import { Printer } from '../types';
+import { Printer } from '../app/types';
 
 interface PrinterListProps {
   printers: Printer[];


### PR DESCRIPTION
## Summary
- Fix default screen imports in route components
- Correct component and hook paths in ChecklistScreen
- Update PrinterList to import Printer type from the proper location

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f6d5f6e3c8333b343f523be8c5c7e